### PR TITLE
exclude rails 5.0.0 with < ruby 2.2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,11 @@ env:
   - "RAILS_VERSION=5.0.0"
 
 matrix:
-  allow_failures:
+  exclude:
     - env: "RAILS_VERSION=5.0.0"
-      rvm:
-        - 2.0.0
-        - 2.1.7
+      rvm: 2.0.0
+    - env: "RAILS_VERSION=5.0.0"
+      rvm: 2.1.7
 
 notifications:
   recipients:


### PR DESCRIPTION
Let's exclude the builds which are rails 5.0.0 and below ruby 2.2.2, because rails 5.0.0 (in fact rack 2.0) requires ruby 2.2.2 or higher.