### PR TITLE
Fix double-escaping of HTML entities when truncation happens

### DIFF
--- a/lib/meta_tags-rails/text_normalizer.rb
+++ b/lib/meta_tags-rails/text_normalizer.rb
@@ -114,8 +114,8 @@ module MetaTags
     # @param [String] natural_separator natural separator to truncate at.
     # @return [String] truncated string.
     #
-    def self.truncate(string, limit = nil, natural_separator = ' ')
-      string = helpers.truncate(string, length: limit, separator: natural_separator, omission: '') if limit
+    def self.truncate(string, limit = nil, natural_separator = ' ', escape = true)
+      string = helpers.truncate(string, length: limit, separator: natural_separator, omission: '', escape: escape) if limit
       string
     end
 
@@ -134,7 +134,7 @@ module MetaTags
       string_array.each do |string|
         limit_left = limit - length - (result.any? ? separator.length : 0)
         if string.length > limit_left
-          result << truncate(string, limit_left, natural_separator)
+          result << truncate(string, limit_left, natural_separator, false)
           break
         end
         length += (result.any? ? separator.length : 0) + string.length

--- a/spec/view_helper/title_spec.rb
+++ b/spec/view_helper/title_spec.rb
@@ -136,6 +136,20 @@ describe MetaTags::ViewHelper do
         expect(meta).to eq('<title>anotherTitle -:+ someTitle -:+ someSite</title>')
       end
     end
+
+    it 'should not double-escape quotes' do
+      subject.title(%{Don't double-escape me})
+      subject.display_meta_tags(site: 'someSite').tap do |meta|
+        expect(meta).to eq('<title>someSite | Don&#39;t double-escape me</title>')
+      end
+    end
+
+    it 'should not double-escape quotes when string is truncated for length' do
+      subject.title(%{Don't double-escape this really extremely long title that goes over the length limit for titles})
+      subject.display_meta_tags(site: 'someSite').tap do |meta|
+        expect(meta).to eq('<title>someSite | Don&#39;t double-escape this really extremely long title</title>')
+      end
+    end
   end
 
   context '.display_title' do


### PR DESCRIPTION
This one took a while to track down!

If the title is truncated, entities such as the apostrophe (`&#39;`) were being double-escaped. This is because the truncate function was calling down to the Rails truncate function, which escapes by default.

I've added some specs to defend this behaviour. Let me know if you need anything else!